### PR TITLE
Allow anonymous admins to use cmds + avoid trying to ban them

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -72,10 +72,10 @@ async def main_handler(bot, message):
     a_id = message.sender_chat.id
     if (await whitelist_check(chat_id, a_id)):
         return
+    elif a_id is chat_id:
+        return
     try:
         res = await bot.ban_chat_member(chat_id, a_id)
-    if a_id is chat_id:
-        return
     except:
         return await message.reply_text("Promote me as admin, to use me")
     if res:

--- a/bot.py
+++ b/bot.py
@@ -72,12 +72,10 @@ async def main_handler(bot, message):
     a_id = message.sender_chat.id
     if (await whitelist_check(chat_id, a_id)):
         return
-    elif a_id is chat_id:
-        pass
-    else:
-        return
     try:
         res = await bot.ban_chat_member(chat_id, a_id)
+    if a_id is chat_id:
+        return
     except:
         return await message.reply_text("Promote me as admin, to use me")
     if res:

--- a/bot.py
+++ b/bot.py
@@ -72,6 +72,10 @@ async def main_handler(bot, message):
     a_id = message.sender_chat.id
     if (await whitelist_check(chat_id, a_id)):
         return
+    elif a_id is chat_id:
+        pass
+    else:
+        return
     try:
         res = await bot.ban_chat_member(chat_id, a_id)
     except:
@@ -117,6 +121,8 @@ async def cb_handler(bot, query):
         user = await bot.get_chat_member(chat_id, query.from_user.id)
         if user.status == "creator" or user.status == "administrator":
             pass
+        elif message.sender_chat.id is chat_id:
+            pass
         else:
             return await query.answer("This Message is Not For You!", show_alert=True)
         await bot.resolve_peer(an_id)
@@ -132,6 +138,8 @@ async def cban_handler(bot, message):
     chat_id = message.chat.id
     user = await bot.get_chat_member(message.chat.id, message.from_user.id)
     if user.status == "creator" or user.status == "administrator":
+        pass
+    elif message.sender_chat.id is chat_id:
         pass
     else:
         return
@@ -158,6 +166,7 @@ async def cban_handler(bot, message):
 async def uncban_handler(bot, message):
     chat_id = message.chat.id
     user = await bot.get_chat_member(message.chat.id, message.from_user.id)
+    
     if user.status == "creator" or user.status == "administrator":
         pass
     else:
@@ -187,6 +196,8 @@ async def add_whitelist_handler(bot, message):
     user = await bot.get_chat_member(chat_id, message.from_user.id)
     if user.status == "creator" or user.status == "administrator":
         pass
+    elif message.sender_chat.id is chat_id:
+        pass
     else:
         return
     try:
@@ -210,6 +221,8 @@ async def del_whitelist_handler(bot, message):
     user = await bot.get_chat_member(chat_id, message.from_user.id)
     if user.status == "creator" or user.status == "administrator":
         pass
+    elif message.sender_chat.id is chat_id:
+        pass
     else:
         return
     try:
@@ -232,6 +245,8 @@ async def del_whitelist_handler(bot, message):
     chat_id = message.chat.id
     user = await bot.get_chat_member(chat_id, message.from_user.id)
     if user.status == "creator" or user.status == "administrator":
+        pass
+    elif message.sender_chat.id is chat_id:
         pass
     else:
         return


### PR DESCRIPTION
Allow anonymous admins to use admin commands in AntiChannelBot. And, avoid bot trying to ban anonymous admins.
## ChangeLog ##
* Allow anonymous admins to use admin cmds
* Avoid bot from trying to ban anonymous admins.
### Allow anonymous admins to use admin cmds
Allow anonymous admins to use admin commands with bot. For more, view this message below.
[![Telegram: View message](https://img.shields.io/badge/View_Message-blue?style=for-the-badge&logo=telegram&logoColor=white)](https://telegram.me/JV_Community/21452)
```python
if message.sender_chat.id is message.chat.id:
    pass
```
### Avoid bot from trying to ban anonymous admins
Added `return` to prevent bot from trying to ban anonymous admins and replying "**Promote me as admin, to use me**" message.
```python
if a_id is chat_id:
    return
```
## Tasks
- [x] **Tried**
- [x] **Tested**